### PR TITLE
Update template file format to use property tables

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -21,40 +21,19 @@ and inter-relatable content objects.
 
 ## Properties
 
-- id
-  - type: idString
-  - minCount: 1
-  - maxCount: 1
-- name
-  - type: xsd:string
-  - maxCount: 1
-- summary
-  - type: xsd:string
-  - maxCount: 1
-- description
-  - type: xsd:string
-  - maxCount: 1
-- comment
-  - type: xsd:string
-  - maxCount: 1
-- specVersion
-  - type: xsd:string
-- createdTime
-  - type: xsd:dateTime
-- createdBy
-  - type: Identity
-- profile
-  - type: ProfileIdentifier
-  - minCount: 1
-- dataLicense
-  - type: xsd:string
-- profile
-  - type: ProfileIdentifier
-  - minCount: 1
-- externalReference
-  - type: ExternalReference | 0 | * | |
-- extension
-  - type: Extension | 0 | * | |
-- verifiedUsing
-  - type: IntegrityMethod
-
+| property    | type         | minCount | maxCount | format |
+| ----------- | ------------ | -------- | -------- | ------ |
+| id          | idString     | 1        | 1        |        |
+| name        | xsd:string   |          | 1        |        |
+| summary     | xsd:string   |          | 1        |        |
+| description | xsd:string   |          | 1        |        |
+| comment     | xsd:string   |          | 1        |        |
+| specVersion | xsd:string   |          |          |        |
+| createdTime | xsd:dateTime |          |          |        |
+| createdBy   | Identity     |          |          |        |
+| profile     | ProfileIdentifier | 1   |          |        |
+| dataLicense | xsd:string   |          |          |        |
+| profile     | ProfileIdentifier | 1   |          |        |
+| externalReference | ExternalReference | 0 | *    |        |
+| extension   | Extension    | 0        | *        |        |
+| verifiedUsing | IntegrityMethod |     |          |        |


### PR DESCRIPTION
Using bullet lists instead of tables for class properties is less readable and more error prone.  Converting the "Element" class properties verbatim from bullet lists to a table makes data entry errors obvious by visual inspection:
1) most properties are missing minCount, maxCount, or both
2) the "profile" property is listed twice

These errors are easily spotted and easily corrected when using table format.